### PR TITLE
Use UTC time for position calculation to avoid DST errors

### DIFF
--- a/apps/calendar/src/controller/times.spec.ts
+++ b/apps/calendar/src/controller/times.spec.ts
@@ -131,7 +131,6 @@ describe('times controller', () => {
         )
       ).toBe(50);
     });
-
   });
 
   it('getPrevGridTime', () => {

--- a/apps/calendar/src/controller/times.spec.ts
+++ b/apps/calendar/src/controller/times.spec.ts
@@ -102,6 +102,36 @@ describe('times controller', () => {
         )
       ).toBeLessThanOrEqual(50);
     });
+
+    it('On a daylight change', () => {
+      // 2020-05-16T00:00:00 is middle time between 2020-01-01T00:00:00 and 2021-01-01T00:00:00. return 50%
+      // at a daylight change
+      expect(
+        getTopPercentByTime(
+          new TZDate('2026-03-08T12:00:00'),
+          new TZDate('2026-03-08T00:00:00'),
+          new TZDate('2026-03-09T00:00:00')
+        )
+      ).toBe(50);
+    });
+
+    it('On a year change', () => {
+      expect(
+        getTopPercentByTime(
+          new TZDate('2026-01-01T12:00:00'),
+          new TZDate('2026-01-01T00:00:00'),
+          new TZDate('2026-01-02T00:00:00')
+        )
+      ).toBe(50);
+      expect(
+        getTopPercentByTime(
+          new TZDate('2025-12-31T12:00:00'),
+          new TZDate('2025-12-31T00:00:00'),
+          new TZDate('2026-01-01T00:00:00')
+        )
+      ).toBe(50);
+    });
+
   });
 
   it('getPrevGridTime', () => {

--- a/apps/calendar/src/controller/times.ts
+++ b/apps/calendar/src/controller/times.ts
@@ -5,15 +5,33 @@ import { limit, ratio } from '@src/utils/math';
 import type { TimeUnit } from '@t/events';
 
 /**
+ * Convert a date to UTC milliseconds using its local time components.
+ * This avoids DST issues by treating the local time as if it were UTC.
+ */
+function toUTCTime(d: TZDate) {
+  return Date.UTC(
+    d.getFullYear(),
+    d.getMonth(),
+    d.getDate(),
+    d.getHours(),
+    d.getMinutes(),
+    d.getSeconds(),
+    d.getMilliseconds()
+  );
+}
+
+/**
  * @param date
  * @param {TZDate} [start] - start time
  * @param {TZDate} [end] - end time
  * @returns {number} The percent value represent current time between start and end
  */
 export function getTopPercentByTime(date: TZDate, start: TZDate, end: TZDate) {
-  const startTime = start.getTime();
-  const endTime = end.getTime();
-  const time = limit(date.getTime(), [startTime], [endTime]) - startTime;
+  // Convert to UTC to avoid DST issues.
+  // This ensures 12:00 noon is always at 50% of a day, regardless of DST.
+  const startTime = toUTCTime(start);
+  const endTime = toUTCTime(end);
+  const time = limit(toUTCTime(date), [startTime], [endTime]) - startTime;
   const max = endTime - startTime;
 
   const topPercent = ratio(max, 100, time);


### PR DESCRIPTION
The position was wrongly calculated because it was using the default time which may have different length on each days during daylight changes. 

Forcing the usage of UTC make it not using any daylight changes, and every day are the same length.
